### PR TITLE
auto-tag: drop stale State=planned mutation; default to Todo

### DIFF
--- a/.github/workflows/auto-tag-issues.yml
+++ b/.github/workflows/auto-tag-issues.yml
@@ -3,9 +3,7 @@ name: Auto-tag new issues
 # Canonical taxonomy: https://github.com/vade-app/vade-coo-memory/blob/main/coo/label_taxonomy.md
 # Canonical project:  https://github.com/orgs/vade-app/projects/1 (VADE)
 #   Project node ID:  PVT_kwDOEGdN_84BUV2r
-#   State field ID:   PVTSSF_lADOEGdN_84BUV2rzhBesRM
-#   planned option:   a5c0cccb
-# When taxonomy v2 lands or the VADE project is rebuilt, batch-update
+# When the VADE project is rebuilt or its fields change, batch-update
 # all 5 repos' workflows together.
 #
 # Mirrors the pilot on vade-coo-memory (see MEMO 2026-04-23-04 and the
@@ -26,9 +24,9 @@ name: Auto-tag new issues
 #     (https://github.com/apps/claude)
 # Optional (graceful skip if absent):
 #   - secrets.VADE_PROJECT_PAT — PAT with `project` scope for the
-#     vade-app org. Enables auto-add to the VADE project with
-#     State=planned. If missing, labeling still runs; the project
-#     step logs a warning and skips.
+#     vade-app org. Enables auto-add to the VADE project. If
+#     missing, labeling still runs; the project step logs a
+#     warning and skips.
 
 on:
   issues:
@@ -80,8 +78,8 @@ jobs:
           prompt: |
             You are a small, deterministic triage routine for the
             `vade-app/vade-governance` repo. You classify one specific
-            issue, apply labels, and add it to the VADE project with
-            State=planned. You do nothing else.
+            issue, apply labels, and add it to the VADE project.
+            You do nothing else.
 
             Target issue number: ${{ github.event.issue.number || inputs.issue_number }}
 
@@ -167,7 +165,7 @@ jobs:
                you intended to apply. If any are missing, retry step
                3 for those.
 
-            5. **Add the issue to the VADE project with State=planned.**
+            5. **Add the issue to the VADE project.**
                Run this exact Bash block, replacing `<ISSUE_ID>` with
                the `id` you got in step 1:
 
@@ -177,13 +175,10 @@ jobs:
                      ITEM_ID=$(GH_TOKEN="$VADE_PROJECT_PAT" gh api graphql \
                        -f query='mutation { addProjectV2ItemById(input: {projectId: "PVT_kwDOEGdN_84BUV2r", contentId: "<ISSUE_ID>"}) { item { id } } }' \
                        -q '.data.addProjectV2ItemById.item.id')
-                     echo "Added to VADE as item $ITEM_ID"
-                     GH_TOKEN="$VADE_PROJECT_PAT" gh api graphql \
-                       -f query="mutation { updateProjectV2ItemFieldValue(input: { projectId: \"PVT_kwDOEGdN_84BUV2r\", itemId: \"$ITEM_ID\", fieldId: \"PVTSSF_lADOEGdN_84BUV2rzhBesRM\", value: { singleSelectOptionId: \"a5c0cccb\" } }) { projectV2Item { id } } }"
-                     echo "Set State=planned"
+                     echo "Added to VADE as item $ITEM_ID (default Status=Todo)"
                    fi
 
-               If the PAT is set and either mutation returns an error,
+               If the PAT is set and the mutation returns an error,
                report the error in your final message but do not retry
                destructively.
 
@@ -206,7 +201,7 @@ jobs:
             terminal state must be verified via `gh` output.
 
             Side-effect budget: labels only, plus the one VADE project
-            item from step 5 (with its State set). Do not edit the
+            item from step 5. Do not edit the
             title or body, do not post a comment, do not assign, do
             not close.
 


### PR DESCRIPTION
## Summary

Drop the `updateProjectV2ItemFieldValue` mutation from the auto-tag workflow in all 5 `vade-app` repos. The mutation pointed at a VADE project field ID (`PVTSSF_…zhBesRM`) and option ID (`a5c0cccb`) that don't exist on the current project — the Status field's real ID is `…zhBesAw` with options `Todo` / `In Progress` / `Done`, no "Planned". The mutation was silently failing; `addProjectV2ItemById` alone is sufficient and new items default to `Status=Todo`, which is the sensible starting state for a newly-triaged issue.

## Why

- **Removes per-project field/option-ID coupling.** Future VADE project rebuilds or field renames won't silently break triage.
- **Eliminates the silent-failure surface.** The workflow's in-prompt agent was reporting "Set State=planned" despite the mutation returning errors, because the surrounding `if $VADE_PROJECT_PAT …` block masked the error.
- **Aligns with "don't carry scaffolding you don't need."** `Todo` is the right default; if the project needs a `Planned` option later, add it once and re-introduce a single mutation.

## Context

- Drift report: [`vade-app/vade-coo-memory#105`](https://github.com/vade-app/vade-coo-memory/issues/105)
- Superseded intent: [MEMO 2026-04-24-02](https://github.com/vade-app/vade-coo-memory/blob/main/coo/memos.md#memo-2026-04-24-02-auto-tag-v2-rolled-out-to-all-five-repos-readinessprio-omit-bias-relaxed-project-assignment-step-wired-but-pat-pending) "Decision (project assignment)" block — the `State=planned` part of that decision is retired.
- PAT was provisioned 2026-04-24 and verified end-to-end via:
  - `vade-runtime#41` dispatch, run [24891254739](https://github.com/vade-app/vade-runtime/actions/runs/24891254739)
  - `vade-coo-memory#105` organic `issues.opened`, run [24891424842](https://github.com/vade-app/vade-coo-memory/actions/runs/24891424842)

Both runs show `addProjectV2ItemById` lands the item; `updateProjectV2ItemFieldValue` silently errors.

## Test plan

- [ ] PR merges to `main`
- [ ] Workflow dispatches successfully (`gh workflow run auto-tag-issues.yml --field issue_number=<n>`)
- [ ] Target issue shows on VADE project with `status.name: "Todo"` (`gh issue view <n> --json projectItems`)
- [ ] Run log contains no "Could not resolve" or `updateProjectV2ItemFieldValue` error strings
- [ ] Organic `issues.opened` event on a fresh issue produces the same outcome

## Cross-repo coordination

Identical patch landing in all 5 `vade-app` repos as separate PRs:

- [ ] `vade-coo-memory` (+ `docs/auto-tag-routine.md` run-log update)
- [ ] `vade-runtime`
- [ ] `vade-core`
- [ ] `vade-governance`
- [ ] `vade-agent-logs`