### PR TITLE
coo-on-assign: remove proactive end-session instruction from launch prompt

### DIFF
--- a/.github/workflows/coo-on-assign.yml
+++ b/.github/workflows/coo-on-assign.yml
@@ -82,9 +82,9 @@ jobs:
               `3a. readiness:ready-to-pick-up (or absent label on a well-scoped body): implement autonomously. Open a PR when the change is complete and the verification steps in the issue (or your judgement of equivalent steps) have run green. Auto-subscribe per the PR-watch discipline in CLAUDE.md. Stand by for review.`,
               `3b. readiness:needs-design / readiness:needs-research / readiness:needs-breakdown, or any clarification-shaped signal in the body: do preliminary reconnaissance, draft a plan, then post a brief comment on the issue (or open a discussion thread for larger scope) that names what you understood, what the design space is, which decisions Ven needs to make, and your recommendation. Stop after the brief — wait for Ven.`,
               `3c. needs:bdfl-approval: never merge autonomously. Always brief, never autonomous, regardless of the readiness label.`,
-              `4. End-of-session discipline applies — episodic Mem0 entry, session log in vade-agent-logs, /memo-sync if a memo was issued.`,
+              `4. When the task above is complete, stand by — do not proactively invoke /end-session or otherwise wrap. Async sessions stay idle until Ven re-engages or the idle-watchdog runs mechanical session-close. End-of-session is a Ven-trigger or watchdog-trigger in this context, NOT an agent-initiated one. Wrapping prematurely after a brief means the session is unavailable when Ven arrives to continue.`,
               ``,
-              `Ven is not currently at the keyboard. Don't expect interactive clarification mid-task; if you would have asked, brief instead.`,
+              `Ven is not currently at the keyboard at session start. Don't expect interactive clarification mid-task; if you would have asked, brief instead. But Ven may engage at any time — if a message arrives mid-session, switch to interactive mode and continue.`,
             ].join('\n');
 
             // --- Compose the pre-fill URL ---------------------------


### PR DESCRIPTION
Closes: n/a — byte-identical sync of vade-coo-memory#836's coo-on-assign launch-prompt fix to this repo.

## Summary

Sibling sync of vade-coo-memory#836. Replaces step 4 of the coo-on-assign launch prompt: instead of "End-of-session discipline applies — episodic Mem0 entry, session log in vade-agent-logs, /memo-sync if a memo was issued" (which prompts the agent to wrap proactively), the new step 4 directs the agent to **stand by** and treat end-session as a Ven-trigger or idle-watchdog-trigger, never agent-initiated.

## Why

Per Ven (the vade-coo-memory#834 fix session): "These sessions should be treated as only initial async — I will interact with them as needed." The previous step-4 instruction caused agents to invoke `/end-session` immediately after a brief or implementation, write the session-end marker, and effectively wind down. When Ven arrived to continue interactively, the session was unavailable.

Full design context in vade-coo-memory#836.

## Cross-repo sync

This workflow file is byte-identical across all 9 vade-app/* repos. This PR is part of the 9-PR fan-out following the same pattern as vcm#815 / vcm#821.

## Test plan

- [x] YAML parses (workflow is a `github-script` step; YAML structure unchanged).
- [x] File contents byte-identical to vade-coo-memory's post-edit version (verified by sha256sum at copy time).
- [ ] Next `@vade-coo` assignment on this repo: confirm the posted launch URL's prompt has the new step 4.

## Refs

- vade-coo-memory#836 (canonical PR; this is the sibling sync)
- vade-coo-memory#834 (originating context — interactive flag during async session)
- MEMO-2026-05-21-bh7h (assign-link primitive)

https://claude.ai/code/session_01XhNXLbqHkqL5RcuK57zNVp